### PR TITLE
Tutorials05 2 Errors Solution for Windows Users

### DIFF
--- a/Tutorial-05/object-loading/glm.cpp
+++ b/Tutorial-05/object-loading/glm.cpp
@@ -444,7 +444,7 @@ glmFirstPass(GLMmodel* model, FILE* file)
     char buf[128];
     
     /* make a default group */
-    group = glmAddGroup(model, "default");
+    group = glmAddGroup(model, (char *)"default");
     
     numvertices = numnormals = numtexcoords = numtriangles = 0;
     while(fscanf(file, "%s", buf) != EOF) {

--- a/Tutorial-05/object-loading/glm.cpp
+++ b/Tutorial-05/object-loading/glm.cpp
@@ -19,6 +19,8 @@
 #include <assert.h>
 #include "glm.h"
 
+// https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?f1url=%3FappId%3DDev16IDEF1%26l%3DEN-US%26k%3Dk(C4996)%26rd%3Dtrue&view=msvc-160
+#pragma warning(disable : 4996)
 
 #define T(x) (model->triangles[(x)])
 

--- a/Tutorial-05/object-loading/main.cpp
+++ b/Tutorial-05/object-loading/main.cpp
@@ -7,7 +7,7 @@
 double eye[] = {0, 0, 1};
 double center[] = {0, 0, 0};
 double up[] = {0, 1, 0};
-char *modelname = "data/al.obj";
+char *modelname = (char *)"data/al.obj";
 
 GLfloat light_ambient[] = {0.0, 0.0, 0.0, 0.0};
 GLfloat light_diffuse[] = {1.0, 1.0, 1.0, 1.0};
@@ -172,16 +172,16 @@ void screen_menu(int value)
 	switch (value)
 	{
 	case '1':
-		modelname = "data/al.obj";
+		modelname = (char *)"data/al.obj";
 		break;
 	case '2':
-		modelname = "data/soccerball.obj";
+		modelname = (char *)"data/soccerball.obj";
 		break;
 	case '3':
-		modelname = "data/rose+vase.obj";
+		modelname = (char *)"data/rose+vase.obj";
 		break;
 	case '4':
-		modelname = "data/apple-ibook-2001.obj";
+		modelname = (char *)"data/apple-ibook-2001.obj";
 		break;
 	}
 	reset();


### PR DESCRIPTION
Upon running the two programs of tutorial 05 faced 2 different errors
1. can't convert const char[9] to char*
    > This Error is solved by explicit casting. using (char *) before string literals in both **main.cpp** and **glm.cpp**
2. POSIX deprecation
    > This is solved by adding a pragma warning disable in the beginning of **glm.cpp** file